### PR TITLE
テストが一括で実行できないバグの修正

### DIFF
--- a/database/seeders/CategoriesTableSeeder.php
+++ b/database/seeders/CategoriesTableSeeder.php
@@ -19,10 +19,12 @@ class CategoriesTableSeeder extends Seeder
 
         $categories = [
             [
+                'id' => 1,
                 'name' => 'Category A',
                 'image_src' => 'https://picsum.photos/id/1015/300/300',
             ],
             [
+                'id' => 2,
                 'name' => 'Category B',
                 'image_src' => 'https://picsum.photos/id/1036/300/300',
             ],

--- a/database/seeders/MaterialsTableSeeder.php
+++ b/database/seeders/MaterialsTableSeeder.php
@@ -19,11 +19,13 @@ class MaterialsTableSeeder extends Seeder
 
         $materials = [
             [
+                'id' => 1,
                 'name' => 'Material A',
                 'content' => 'Teaching Material A',
                 'category_id' => '1',
             ],
             [
+                'id' => 2,
                 'name' => 'Material B',
                 'content' => 'Teaching Material B',
                 'category_id' => '2',

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -16,12 +16,14 @@ class UsersTableSeeder extends Seeder
     {
         $users = [
             [
+                'id' => 1,
                 'name' => 'user',
                 'email' => 'user@example.com',
                 'email_verified_at' => null,
                 'password' => bcrypt('password'),
             ],
             [
+                'id' => 2,
                 'name' => 'admin',
                 'email' => 'admin@example.com',
                 'email_verified_at' => null,


### PR DESCRIPTION
## 原因と解決策
- RefreshDatabaseではIDの自動採番がリセットされなかったことがバグの原因だったためseederにidを追加しました．